### PR TITLE
Improve rpm versioning

### DIFF
--- a/client/nivlheim_client
+++ b/client/nivlheim_client
@@ -53,12 +53,14 @@ my %defaultopt = (
 	'ip'        => 0  # override the ip address auto detection
 	);
 
-# Version and similar info
+# Version information
 my $NAME    = 'nivlheim_client';
-my $VERSION = '0.1.0';
 my $AUTHOR  = 'Øyvind Hagberg';
 my $CONTACT = 'oyvind.hagberg@usit.uio.no';
 my $RIGHTS  = 'USIT/IT-DRIFT/GD/GID, University of Oslo';
+open($F, "/etc/nivlheim/version");
+chomp(my $VERSION = <$F>);
+close($F);
 
 # Usage text
 my $USAGE = <<"END_USAGE";

--- a/client/nivlheim_client
+++ b/client/nivlheim_client
@@ -58,7 +58,7 @@ my $NAME    = 'nivlheim_client';
 my $AUTHOR  = 'Øyvind Hagberg';
 my $CONTACT = 'oyvind.hagberg@usit.uio.no';
 my $RIGHTS  = 'USIT/IT-DRIFT/GD/GID, University of Oslo';
-open($F, "/etc/nivlheim/version");
+open(my $F, "/etc/nivlheim/version");
 chomp(my $VERSION = <$F>);
 close($F);
 

--- a/rpm/nivlheim.spec
+++ b/rpm/nivlheim.spec
@@ -11,7 +11,7 @@ Group:    Applications/System
 License:  GPLv3+
 
 URL:      %{getenv:GIT_URL}
-Source0:  %{getenv:GIT_URL}/archive/%{getenv:GIT_BRANCH}.zip
+Source0:  %{getenv:GIT_URL}/archive/%{getenv:GIT_LOCAL_BRANCH}.zip
 
 BuildRequires: perl(Archive::Tar)
 BuildRequires: perl(Archive::Zip)

--- a/rpm/nivlheim.spec
+++ b/rpm/nivlheim.spec
@@ -104,7 +104,7 @@ This package contains the client component of Nivlheim.
 This package contains the server components of Nivlheim.
 
 %prep
-%autosetup -n nivlheim-master
+%autosetup -n %{name}-%{getenv:GIT_BRANCH}
 
 %build
 
@@ -197,8 +197,8 @@ rm -rf %{buildroot}
 %systemd_postun_with_restart %{name}.service
 
 %changelog
-* Thu Sep 14 2017 Øyvind Hagberg <oyvind.hagberg@usit.uio.no>
+* Thu Sep 14 2017 Øyvind Hagberg <oyvind.hagberg@usit.uio.no> - 0.1.0-20170914
 - Use macros for Source0 and URL. Values come from Jenkins
 
-* Fri Jul 21 2017 Øyvind Hagberg <oyvind.hagberg@usit.uio.no>
+* Fri Jul 21 2017 Øyvind Hagberg <oyvind.hagberg@usit.uio.no> - 0.1.0-20170721
 - First package build

--- a/rpm/nivlheim.spec
+++ b/rpm/nivlheim.spec
@@ -11,7 +11,7 @@ Group:    Applications/System
 License:  GPLv3+
 
 URL:      %{getenv:GIT_URL}
-Source0:  %{getenv:GIT_URL}/archive/%{getenv:GIT_LOCAL_BRANCH}.zip
+Source0:  %{getenv:GIT_URL}/archive/%{getenv:GIT_BRANCH}.zip
 
 BuildRequires: perl(Archive::Tar)
 BuildRequires: perl(Archive::Zip)

--- a/rpm/nivlheim.spec
+++ b/rpm/nivlheim.spec
@@ -1,8 +1,8 @@
-%global date 20170721
+%global date %(date +"%Y%m%d")
 
 # Semantic Versioning http://semver.org/
 Name:     nivlheim
-Version:  0.1.0
+Version:  %{getenv:GIT_TAG}
 Release:  %{date}%{?dist}
 
 Summary:  File collector
@@ -10,8 +10,8 @@ Summary:  File collector
 Group:    Applications/System
 License:  GPLv3+
 
-URL:      https://github.com/oyvindhagberg/nivlheim
-Source0:  https://github.com/oyvindhagberg/nivlheim/archive/master.zip
+URL:      %{getenv:GIT_URL}
+Source0:  %{getenv:GIT_URL}/archive/%{getenv:GIT_BRANCH}.zip
 
 BuildRequires: perl(Archive::Tar)
 BuildRequires: perl(Archive::Zip)
@@ -141,6 +141,7 @@ cp -r server/web %{buildroot}%{_localstatedir}/nivlheim/go/src/
 cp -r server/jobrunner %{buildroot}%{_localstatedir}/nivlheim/go/src/
 cp server/templates/* %{buildroot}/var/www/nivlheim/templates/
 cp -r server/static/* %{buildroot}%{_localstatedir}/www/html/static/
+echo %{version} > %{buildroot}%{_sysconfdir}/nivlheim/version
 
 %check
 perl -c %{buildroot}%{_sbindir}/nivlheim_client
@@ -161,6 +162,7 @@ rm -rf %{buildroot}
 %doc README.md
 %dir %{_localstatedir}/nivlheim
 %dir %{_sysconfdir}/nivlheim
+%{_sysconfdir}/nivlheim/version
 
 %files client
 %defattr(-, root, root, -)
@@ -195,5 +197,8 @@ rm -rf %{buildroot}
 %systemd_postun_with_restart %{name}.service
 
 %changelog
-* Fri Jul 21 2017 Øyvind Hagberg <oyvind.hagberg@usit.uio.no> - 0.1.0-20170721
+* Thu Sep 14 2017 Øyvind Hagberg <oyvind.hagberg@usit.uio.no>
+- Use macros for Source0 and URL. Values come from Jenkins
+
+* Fri Jul 21 2017 Øyvind Hagberg <oyvind.hagberg@usit.uio.no>
 - First package build


### PR DESCRIPTION
Use the version number from the Github release tag when building RPMs.  
Remove the hard coded version numbers from the spec file. The version number is determined during RPM build by using environment variables made available by Jenkins.

This means the version number is only set in one place: The Github release tag.

This pull request also does a few other things:
- The date is no longer hard coded in the spec file, instead the current date on the system is used.
- The current Git branch and url are no longer hard coded, but supplied from Jenkins through environment variables.
- During build, a file /etc/nivlheim/version is created and packaged. It contains the version number. It means that on a machine where a nivlheim package is installed, the release/version can be determined by looking at this file.