### PR TITLE
Build and test RPM packages on VMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Getting started
 ### Install the server
-1. Spin up a clean VM running Fedora 27, 26 or RHEL 7
-2. Configure the package repository:
+1. Spin up a clean VM running Fedora 27, 26, RHEL 7, or CentOS 7
+2. If you're using RHEL or CentOS, you need to [enable the EPEL package repository](https://fedoraproject.org/wiki/EPEL).
+3. Configure the package repository:
 ```
 sudo dnf copr enable oyvindh/Nivlheim
 ```
@@ -9,11 +10,11 @@ or go to [the project page at Fedora Copr](https://copr.fedorainfracloud.org/cop
 download the appropriate repository config file, and place it in 
 `/etc/yum.repos.d/`  
 
-3. Install the packages:
+4. Install the packages:
 ```
 sudo dnf -y install nivlheim-server nivlheim-client
 ```
-4. Open the web admin interface in a browser:
+5. Open the web admin interface in a browser:
 `https://<your server>/`
 
 At this point, there's no data in the system, because no clients have been configured yet.
@@ -61,5 +62,5 @@ Copy `/var/www/nivlheim/CA/nivlheimca.crt` from the server, and place it in `/va
 
 # How to contribute
 - Do you have a suggestion, feature request, or idea? Or have you found a bug? Go to the "issues" page and create a new issue! Everything is welcome.
-- Would you like to contribute code? Fork the repository and create a pull request!
+- Would you like to contribute code? Fork the repository and create a pull request! We try to use the [GitHub workflow](https://guides.github.com/introduction/flow/). You can also ask to be added as a collaborator.
 - Questions? Contact me at oyvind.hagberg@usit.uio.no

--- a/rpm/buildrpm.sh
+++ b/rpm/buildrpm.sh
@@ -84,7 +84,8 @@ do
 	echo "--------------------------------------------------------"
 	echo "  Mock-building packages for $config"
 	echo "--------------------------------------------------------"
-	if ! mock --root=$config --quiet --rebuild $srpm; then
+	if ! mock --bootstrap-chroot --root=$config --quiet --rebuild $srpm; then
+		echo "Mock build failed for $config."
 		echo "------------ build.log -------------"
 		cat /var/lib/mock/$config/result/build.log
 		echo "------------------------------------"
@@ -92,6 +93,7 @@ do
 	fi
 	rm -f /var/lib/mock/$config/result/*.src.rpm
 	rpmlint -i /var/lib/mock/$config/result/*.rpm || exit 1
+	echo ""
 
 	#if [ "$GIT_BRANCH" = "origin/master" ]; then
 	#	cp -v /var/lib/mock/$config/result/*.rpm /var/www/html/repo || exit 1

--- a/rpm/run_tests_on_vms.sh
+++ b/rpm/run_tests_on_vms.sh
@@ -79,6 +79,7 @@ for IMAGE in "${IMAGES[@]}"; do
 	echo ""
 	if [ ! $OK -eq 1 ]; then
 		echo "Unable to connect to the VM, giving up."
+		LOGFILE=""
 	else
 		echo "Installing and testing packages"
 		ssh $USER\@$IP -o StrictHostKeyChecking=no \
@@ -102,7 +103,8 @@ for IMAGE in "${IMAGES[@]}"; do
 			STATUS="success"
 		fi
 		URL=""
-		if [ -f $LOGFILE ]; then URL="http://folk.uio.no/oyvihag/logs/$LOGFILE"; fi
+		if [[ "$LOGFILE" != "" ]] && [[ -f $LOGFILE ]];
+		then URL="https://folk.uio.no/oyvihag/logs/$LOGFILE"; fi
 		curl -XPOST -H "Authorization: token $GITHUB_TOKEN" \
 			https://api.github.com/repos/usit-gd/nivlheim/statuses/$GIT_COMMIT -d "{
 			\"state\": \"$STATUS\",

--- a/rpm/run_tests_on_vms.sh
+++ b/rpm/run_tests_on_vms.sh
@@ -101,7 +101,7 @@ for IMAGE in "${IMAGES[@]}"; do
 
 	if [[ "$GITHUB_TOKEN" != "" ]] && [[ "$GIT_COMMIT" != "" ]]; then
 		STATUS="failure"
-		if [ grep -c END_TO_END_SUCCESS "$LOGFILE" -gt 0 ]; then
+		if [ $(grep -c END_TO_END_SUCCESS "$LOGFILE") -gt 0 ]; then
 			STATUS="success"
 		fi
 		URL=""

--- a/rpm/run_tests_on_vms.sh
+++ b/rpm/run_tests_on_vms.sh
@@ -6,24 +6,41 @@
 # THAT IS SHOWN ONLY ONCE. Read about it here:
 # http://docs.uh-iaas.no/en/latest/login.html#first-time-login
 
-# 2. Install and configure the CLI tools: 
+# 2. Install and configure the CLI tools:
 # http://docs.uh-iaas.no/en/latest/api.html#openstack-command-line-interface-cli
 
 # 3. You can now run commands to create/modify/delete VMs
 
-
 source ~/keystone_rc.sh # provides environment variables with authentication information
+source ~/github_rc.sh # provides GitHub API token
 
-openstack image list | grep active | cut -d '|' -f 3 | while read IMAGE
-do
+# Create an array containing the available machine images
+TMPFILE=$(mktemp)
+openstack image list | grep active | cut -d '|' -f 3 > $TMPFILE
+IFS=$'\r\n' GLOBIGNORE='*' command eval  'IMAGES=($(cat ${TMPFILE}))'
+rm $TMPFILE
+
+for IMAGE in "${IMAGES[@]}"; do
 	if [[ $IMAGE != *"Fedora"* ]] && [[ $IMAGE != *"CentOS 7"* ]]; then
 		continue
+	fi
+	IMAGE=$(echo $IMAGE | xargs) # trim leading/trailing whitespace
+
+	if [[ $GITHUB_TOKEN != "" ]] && [[ $GIT_COMMIT != "" ]]; then
+		curl -XPOST -H "Authorization: token $GITHUB_TOKEN" \
+			https://api.github.com/repos/usit-gd/nivlheim/statuses/$GIT_COMMIT -d "{
+			\"state\": \"pending\",
+			\"target_url\": \"\",
+			\"description\": \"Results are pending...\",
+			\"context\": \"$IMAGE\"
+		}" -sS -o /dev/null
 	fi
 
 	echo "Creating a VM with \"$IMAGE\""
 	NAME="voyager"
 	openstack server create --image "$IMAGE" --flavor m1.small \
-		--key-name oyvihag_usit_key --nic net-id=dualStack --wait $NAME
+		--key-name jenkins_key --nic net-id=dualStack --wait $NAME \
+		> /dev/null
 	IP=$(openstack server list | grep $NAME | \
 		grep -oE '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')
 	echo "IP address: \"$IP\""
@@ -35,19 +52,36 @@ do
 	if [[ $IMAGE == *"CirrOS"* ]]; then USER=cirros; fi
 	echo "User: $USER"
 
-	echo "Waiting for the VM to finish booting"
-	until (echo bleh | nc -w 2 $IP 22); do
-		sleep 10
+	echo -n "Waiting for the VM to finish booting"
+	until (echo bleh | nc -w 2 $IP 22 1>/dev/null 2>/dev/null); do
+		sleep 5
+		echo -n ".."
 	done
+	echo ""
 
-	LOCALFILE="test_packages.sh"
+	echo "Installing and testing packages"
 	ssh $USER\@$IP -o StrictHostKeyChecking=no \
-		-o UserKnownHostsFile=/dev/null \
-		-C "cat > $LOCALFILE" < $LOCALFILE
+		-q -o UserKnownHostsFile=/dev/null \
+		-C "cat > script" < $(dirname "$0")"test_packages.sh"
 
+	LOGFILE="log $IMAGE.txt"
 	ssh $USER\@$IP -o StrictHostKeyChecking=no \
-		-o UserKnownHostsFile=/dev/null \
-		-C "chmod a+x $LOCALFILE; ./$LOCALFILE" > "log $IMAGE.txt" 2>&1
+		-q -o UserKnownHostsFile=/dev/null \
+		-C "chmod a+x script; ./script" > $LOGFILE 2>&1
 
 	openstack server delete --wait $NAME
+
+	if [[ $GITHUB_TOKEN != "" ]] && [[ $GIT_COMMIT != "" ]]; then
+		STATUS="failure"
+		if [ grep -c END_TO_END_SUCCESS "$LOGFILE" -gt 0 ]; then
+			STATUS="success"
+		fi
+		curl -XPOST -H "Authorization: token $GITHUB_TOKEN" \
+			https://api.github.com/repos/usit-gd/nivlheim/statuses/$GIT_COMMIT -d "{
+			\"state\": \"$STATUS\",
+			\"target_url\": \"\",
+			\"description\": \"$STATUS\",
+			\"context\": \"$IMAGE\"
+		}" -sS -o /dev/null
+	fi
 done

--- a/rpm/run_tests_on_vms.sh
+++ b/rpm/run_tests_on_vms.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# How to use OpenStack and UH-IaaS
+
+# 1. Sign up for UH-IaaS, and MAKE SURE TO WRITE DOWN THE API PASSWORD
+# THAT IS SHOWN ONLY ONCE. Read about it here:
+# http://docs.uh-iaas.no/en/latest/login.html#first-time-login
+
+# 2. Install and configure the CLI tools: 
+# http://docs.uh-iaas.no/en/latest/api.html#openstack-command-line-interface-cli
+
+# 3. You can now run commands to create/modify/delete VMs
+
+
+source ~/keystone_rc.sh # provides environment variables with authentication information
+
+openstack image list | grep active | cut -d '|' -f 3 | while read IMAGE
+do
+	if [[ $IMAGE != *"Fedora"* ]] && [[ $IMAGE != *"CentOS 7"* ]]; then
+		continue
+	fi
+
+	echo "Creating a VM with \"$IMAGE\""
+	NAME="voyager"
+	openstack server create --image "$IMAGE" --flavor m1.small \
+		--key-name oyvihag_usit_key --nic net-id=dualStack --wait $NAME
+	IP=$(openstack server list | grep $NAME | \
+		grep -oE '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')
+	echo "IP address: \"$IP\""
+	USER=root
+	if [[ $IMAGE == *"CentOS"* ]]; then USER=centos; fi
+	if [[ $IMAGE == *"Fedora"* ]]; then USER=fedora; fi
+	if [[ $IMAGE == *"Ubuntu"* ]]; then USER=ubuntu; fi
+	if [[ $IMAGE == *"Debian"* ]]; then USER=debian; fi
+	if [[ $IMAGE == *"CirrOS"* ]]; then USER=cirros; fi
+	echo "User: $USER"
+
+	echo "Waiting for the VM to finish booting"
+	until (echo bleh | nc -w 2 $IP 22); do
+		sleep 10
+	done
+
+	LOCALFILE="test_packages.sh"
+	ssh $USER\@$IP -o StrictHostKeyChecking=no \
+		-o UserKnownHostsFile=/dev/null \
+		-C "cat > $LOCALFILE" < $LOCALFILE
+
+	ssh $USER\@$IP -o StrictHostKeyChecking=no \
+		-o UserKnownHostsFile=/dev/null \
+		-C "chmod a+x $LOCALFILE; ./$LOCALFILE" > "log $IMAGE.txt" 2>&1
+
+	openstack server delete --wait $NAME
+done

--- a/rpm/test_packages.sh
+++ b/rpm/test_packages.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -x
+
+if [ -f /etc/fedora-release ]; then
+	sudo dnf copr enable oyvindh/Nivlheim-test
+	sudo dnf install -y nivlheim-client nivlheim-server || touch installerror
+elif [ -f /etc/redhat-release ]; then
+	sudo yum install -y epel-release
+	sudo curl -o /etc/yum.repos.d/oyvindh-Nivlheim-test-epel-7.repo \
+		https://copr.fedorainfracloud.org/coprs/oyvindh/Nivlheim-test/repo/epel-7/oyvindh-Nivlheim-test-epel-7.repo
+	sudo yum install -y nivlheim-client nivlheim-server || touch installerror
+fi
+
+if [ -f installerror ]; then
+	echo "Package installation failed."
+	exit
+fi

--- a/rpm/test_packages.sh
+++ b/rpm/test_packages.sh
@@ -29,7 +29,7 @@ echo "server=localhost" | sudo tee -a /etc/nivlheim/client.conf
 sudo /usr/sbin/nivlheim_client
 sudo -u apache psql -c 'update waiting_for_approval set approved=true;'
 sudo /usr/sbin/nivlheim_client
-if [ ! -f /var/nivlheim/my.crt ]; authenticate
+if [ ! -f /var/nivlheim/my.crt ]; then
 	echo "Certificate generation failed."
 	exit
 fi

--- a/rpm/test_packages.sh
+++ b/rpm/test_packages.sh
@@ -1,10 +1,14 @@
 #!/bin/bash
 set -x
 
+# This is intended to be an end-to-end test of the server and client packages.
+# It should signal success by outputting "END_TO_END_SUCCESS" if and only if
+# the test(s) succeeded.
+
 if [ -f /etc/fedora-release ]; then
-	sudo dnf copr enable oyvindh/Nivlheim-test
+	sudo dnf copr -y enable oyvindh/Nivlheim-test
 	sudo dnf install -y nivlheim-client nivlheim-server || touch installerror
-elif [ -f /etc/redhat-release ]; then
+elif [ -f /etc/centos-release ]; then
 	sudo yum install -y epel-release
 	sudo curl -o /etc/yum.repos.d/oyvindh-Nivlheim-test-epel-7.repo \
 		https://copr.fedorainfracloud.org/coprs/oyvindh/Nivlheim-test/repo/epel-7/oyvindh-Nivlheim-test-epel-7.repo
@@ -15,3 +19,25 @@ if [ -f installerror ]; then
 	echo "Package installation failed."
 	exit
 fi
+
+if [ $(curl -s -k https://localhost/ | grep -c "Nivlheim") -eq 0 ]; then
+	echo "The web server isn't properly configured and running."
+	exit
+fi
+
+echo "server=localhost" | sudo tee -a /etc/nivlheim/client.conf
+sudo /usr/sbin/nivlheim_client
+sudo -u apache psql -c 'update waiting_for_approval set approved=true;'
+sudo /usr/sbin/nivlheim_client
+if [ ! -f /var/nivlheim/my.crt ]; authenticate
+	echo "Certificate generation failed."
+	exit
+fi
+
+sleep 10 # wait for server to process incoming data
+if [ $(curl -s -k https://localhost/ | grep -c "novalocal") -eq 0 ]; then
+	echo "Home page does not show the new machine."
+	exit
+fi
+
+echo "END_TO_END_SUCCESS"


### PR DESCRIPTION
This adds two new scripts that are part of the automatic build process. They create VMs for target platforms, and install and test the built packages there. The whole process is run by [Jenkins](https://jenkins.io/).

Two external services are incorporated in the build process:
- [Fedora Copr](https://copr.fedorainfracloud.org/) is leveraged to build binary packages.
- [UH-IaaS](http://www.uh-iaas.no/), built on [OpenStack](https://www.openstack.org/), provides the infrastructure for virtual machines.

This also adds some information to README: 
- About how [EPEL](https://fedoraproject.org/wiki/EPEL) is required for CentOS and RHEL
- About how this projects uses the [GitHub workflow](https://guides.github.com/introduction/flow/)